### PR TITLE
Extract common less variables in KISSY DPL

### DIFF
--- a/src/button/assets/dpl/button.less
+++ b/src/button/assets/dpl/button.less
@@ -13,11 +13,11 @@
 .ks-button {
     padding: 4px 10px 4px;
     font-size: @baseFontSize;
-    color: @grayDark;
+    color: @btnColor;
     text-align: center;
     text-shadow: 0 1px 1px rgba(255, 255, 255, .75);
     vertical-align: middle;
-    .buttonState(@btnBackground, @btnBackgroundHighlight,@grayDark,@grayDark);
+    .buttonState(@btnBackground, @btnBackgroundHighlight, @btnColor, @btnColor);
     border: 1px solid @btnBorder;
     *border: 0; // Remove the border to prevent IE7's black border on input:focus
     border-bottom-color: darken(@btnBorder, 10%);
@@ -68,30 +68,30 @@
 // Set the backgrounds
 // -------------------------
 .ks-button-primary {
-    .buttonState(@btnPrimaryBackground, @btnPrimaryBackgroundHighlight,@white,@btnOtherActiveColor);
+    .buttonState(@btnPrimaryBackground, @btnPrimaryBackgroundHighlight,@btnInverseColor,@btnOtherActiveColor);
 }
 
 // Warning appears are orange
 .ks-button-warning {
-    .buttonState(@btnWarningBackground, @btnWarningBackgroundHighlight,@white,@btnOtherActiveColor);
+    .buttonState(@btnWarningBackground, @btnWarningBackgroundHighlight,@btnInverseColor,@btnOtherActiveColor);
 }
 
 // Danger and error appear as red
 .ks-button-danger {
-    .buttonState(@btnDangerBackground, @btnDangerBackgroundHighlight,@white,@btnOtherActiveColor);
+    .buttonState(@btnDangerBackground, @btnDangerBackgroundHighlight,@btnInverseColor,@btnOtherActiveColor);
 }
 
 // Success appears as green
 .ks-button-success {
-    .buttonState(@btnSuccessBackground, @btnSuccessBackgroundHighlight,@white,@btnOtherActiveColor);
+    .buttonState(@btnSuccessBackground, @btnSuccessBackgroundHighlight,@btnInverseColor,@btnOtherActiveColor);
 }
 
 // Info appears as a neutral blue
 .ks-button-info {
-    .buttonState(@btnInfoBackground, @btnInfoBackgroundHighlight,@white,@btnOtherActiveColor);
+    .buttonState(@btnInfoBackground, @btnInfoBackgroundHighlight,@btnInverseColor,@btnOtherActiveColor);
 }
 
 // Inverse appears as dark gray
 .ks-button-inverse {
-    .buttonState(@btnInverseBackground, @btnInverseBackgroundHighlight,@white,@btnOtherActiveColor);
+    .buttonState(@btnInverseBackground, @btnInverseBackgroundHighlight,@btnInverseColor,@btnOtherActiveColor);
 }

--- a/src/button/assets/dpl/variables.less
+++ b/src/button/assets/dpl/variables.less
@@ -8,23 +8,26 @@
 @btnOtherActiveColor:               rgba(255, 255, 255, .75);
 
 @btnBackground:                     @white;
-@btnBackgroundHighlight:            darken(@white, 10%);
-@btnBorder:                         darken(@white, 20%);
+@btnBackgroundHighlight:            darken(@btnBackground, 10%);
+@btnBorder:                         darken(@btnBackground, 20%);
 
 @btnPrimaryBackground:              @linkColor;
-@btnPrimaryBackgroundHighlight:     spin(@btnPrimaryBackground, 15%);
+@btnPrimaryBackgroundHighlight:     darken(@btnPrimaryBackground, 10%);
 
 @btnInfoBackground:                 #5bc0de;
-@btnInfoBackgroundHighlight:        #2f96b4;
+@btnInfoBackgroundHighlight:        darken(@btnInfoBackground, 10%);
 
 @btnSuccessBackground:              #62c462;
-@btnSuccessBackgroundHighlight:     #51a351;
+@btnSuccessBackgroundHighlight:     darken(@btnSuccessBackground, 10%);
 
 @btnWarningBackground:              lighten(@orange, 15%);
-@btnWarningBackgroundHighlight:     @orange;
+@btnWarningBackgroundHighlight:     darken(@btnWarningBackground, 10%);
 
 @btnDangerBackground:               #ee5f5b;
-@btnDangerBackgroundHighlight:      #bd362f;
+@btnDangerBackgroundHighlight:      darken(@btnDangerBackground, 10%);
 
 @btnInverseBackground:              @gray;
-@btnInverseBackgroundHighlight:     @grayDarker;
+@btnInverseBackgroundHighlight:     darken(@btnInverseBackground, 10%);
+
+@btnColor:							@grayDark;
+@btnInverseColor:					@white;

--- a/src/combobox/assets/dpl/variables.less
+++ b/src/combobox/assets/dpl/variables.less
@@ -2,7 +2,9 @@
 
 @comboboxTransition: border linear .2s, box-shadow linear .2 s;
 
-@comboboxBorder: 1px solid #CCC;
+@comboboxBorderColor:	#CCC;
+
+@comboboxBorder: 1px solid @comboboxBorderColor;
 
 @comboboxBorderRadius: 3px;
 
@@ -12,4 +14,4 @@
 
 @comboboxFocusedBoxShadown: inset 0 1px 1px rgba(0,0,0,.075), 0 0 8px rgba(82,168,236,.6);
 
-@comboboxTriggerBorderLeft: 1px solid #CCC;
+@comboboxTriggerBorderLeft: 1px solid @comboboxBorderColor;

--- a/src/css/src/dpl/forms.less
+++ b/src/css/src/dpl/forms.less
@@ -51,6 +51,7 @@ textarea[class*="span"] {
 
 // Everything else
 textarea,
+select,
 input[type="text"],
 input[type="password"],
 input[type="datetime"],
@@ -99,7 +100,7 @@ input[type="color"],
 .uneditable-input {
     padding: 4px;
     line-height: @baseLineHeight;
-    color: @gray;
+    color: @inputColor;
 }
 
 input[type="radio"], input[type="checkbox"] {
@@ -144,7 +145,7 @@ select[readonly],
 textarea[readonly] {
     cursor: not-allowed;
     background-color: @inputDisabledBackground;
-    border-color: #ddd;
+    border-color: @inputDisabledColor;
 }
 // Explicitly reset the colors here
 input[type="radio"][disabled],

--- a/src/css/src/dpl/reset-mixin.less
+++ b/src/css/src/dpl/reset-mixin.less
@@ -84,7 +84,7 @@ audio:not([controls]) {
 
 mark {
     background: #ff0;
-    color: #000;
+    color: @textColor;
 }
 
 /*

--- a/src/css/src/dpl/variables.less
+++ b/src/css/src/dpl/variables.less
@@ -114,3 +114,5 @@
 @inputBorderRadius:             3px;
 @inputDisabledBackground:       @grayLighter;
 @formActionsBackground:         #f5f5f5;
+@inputColor:					@gray;
+@inputDisabledColor:			#ddd;

--- a/src/menu/assets/dpl/menu.less
+++ b/src/menu/assets/dpl/menu.less
@@ -31,7 +31,7 @@
     height: 1px;
     margin: ((@baseFontSize*@baseLineHeight / 2) - 1) 1px; // 8px 1px
     overflow: hidden;
-    background-color: #e5e5e5;
+    background-color: @menuDividerBackground;
     border-bottom: 1px solid @white;
 }
 
@@ -49,7 +49,7 @@
     outline: none;
     padding: 4px 0;
     background-color: @menuBackground;
-    border-color: #ccc;
+    border-color: @defaultMenuBorder;
     border-color: @menuBorder;
     border-style: solid;
     border-width: 1px;

--- a/src/menu/assets/dpl/variables.less
+++ b/src/menu/assets/dpl/variables.less
@@ -4,7 +4,11 @@
 @import "../../../css/src/dpl/variables.less";
 
 @menuBackground:            @white;
+@defaultMenuBorder:			#ccc;
 @menuBorder:                rgba(0,0,0,.2);
 @menuitemColor:             @grayDark;
 @menuitemColorHover:        @white;
 @menuitemBackgroundHover:   @linkColor;
+
+
+@menuDividerBackground:		#e5e5e5;

--- a/src/tabs/assets/dpl/tabs.less
+++ b/src/tabs/assets/dpl/tabs.less
@@ -26,6 +26,7 @@
     padding: @tabPadding;
     margin: 0;
     border: @tabBorder;
+    color: lighten(@tabSelectedColor, 15%);
 
     .reset-filter();
     background: none;

--- a/src/tabs/assets/dpl/variables.less
+++ b/src/tabs/assets/dpl/variables.less
@@ -4,15 +4,17 @@
 
 @tabBorder: 1px solid transparent;
 
-@tabHoverBorderColor: @grayLighter;
+@tabHoverColor: @grayLighter;
 
-@tabHoverBackgroundColor: @grayLighter;
+@tabHoverBorderColor: @tabHoverColor;
 
-@tabSelectedColor: @gray;
+@tabHoverBackgroundColor: @tabHoverColor;
 
 @tabSelectedBackgroundColor: @white;
 
-@tabBarBorderColor: #DDD;
+@tabSelectedColor: darken(@tabHoverColor, 40%);
+
+@tabBarBorderColor: darken(@tabHoverColor, 20%);
 
 @tabBarMargin: 18px;
 


### PR DESCRIPTION
To make Kissy DPL easier to be themed, do following:

1, merge less variables, by use less functions like lighten(), darken()
2, move color definition from #widget#.less to #widget#-variables.less

This pull request covers following widgets: combobox, tab, table, form, menu, menu-button, split-button, button, and extract color related definition only.
