### PR TITLE
Update src/editor/src/editor/plugin/image/dialog.js

### DIFF
--- a/src/editor/src/editor/plugin/image/dialog.js
+++ b/src/editor/src/editor/plugin/image/dialog.js
@@ -304,7 +304,7 @@ KISSY.add("editor/plugin/image/dialog", function (S, IO, Editor, Overlay4E, Tabs
 
             ok.on("click", function (ev) {
                 ev.halt();
-                if (S.indexOf(self.tab.getSelectedTab(), self.tab.getTabs()) == 1 && self.cfg) {
+                if (S.indexOf(self.tab.getSelectedTab(), self.tab.getTabs()) == (typeof self.imageCfg['remote'] == 'undefined' ? 1 : 0) && self.cfg) {
 
                     if (!verifyInputs(commonSettingTable.all("input"))) {
                         return;


### PR DESCRIPTION
307行，当将editor的上传图片设置中增加remote:false后，则“本地上传”标签的索引值为0，如果不进行判断则无法上传图片。
