### PR TITLE
fixed issue #326

### DIFF
--- a/src/component/sub-modules/base/src/controller.js
+++ b/src/component/sub-modules/base/src/controller.js
@@ -668,7 +668,27 @@ KISSY.add("component/base/controller", function (S, Box, Event, Component, UIBas
                     value: S.config('component/prefixCls') || 'ks-',
                     view: 1
                 },
+                /**
+                 * This component's prefix xclass. Only be uesd in cfg.
+                 * To use this property as 'xclass' when not specified 'xclass' and 'xtype'
+                 * @cfg {String} prefixXClass
+                 */
+                /**
+                 * @ignore
+                 */
+                prefixXClass : {
 
+                },
+                /**
+                 * This component's xtype, xclass = prefixXClass + xtype.
+                 * @cfg {String} prefixXClass
+                 */
+                /**
+                 * @ignore
+                 */
+                xtype : {
+
+                },
                 /**
                  * This component's parent component.
                  * @type {KISSY.Component.Controller}

--- a/src/component/sub-modules/base/src/impl.js
+++ b/src/component/sub-modules/base/src/impl.js
@@ -36,6 +36,12 @@ KISSY.add("component/base/impl", function (S, UIBase, Manager) {
         var childConstructor, xclass;
         if (component && !component.isController && parent) {
             S.mix(component, parent.get('defaultChildCfg'), false);
+            if(!component.xclass && component.prefixXClass){
+                component.xclass = component.prefixXClass;
+                if(component.xtype){
+                    component.xclass += '-' + component.xtype;
+                }
+            }
         }
         if (component && !component.isController && (xclass = component.xclass)) {
             childConstructor = Manager.getConstructorByXClass(xclass);

--- a/src/component/tests/specs/component-spec.js
+++ b/src/component/tests/specs/component-spec.js
@@ -98,4 +98,82 @@ KISSY.use("component/base", function (S, Component) {
         });
     });
 
+    describe("xclass",function(){
+
+        var A = Component.Controller.extend({
+
+        },{
+            ATTRS : {
+                defaultChildCfg : {
+                    value : {
+                        prefixXClass : 'a-b'
+                    }
+                }
+            }
+        },{
+            xclass : 'a'
+        });
+
+        var B = Component.Controller.extend({},{
+            xclass : 'a-b'
+        });
+
+        var C = B.extend({
+
+        },{
+            xclass : 'a-b-c'
+        });
+
+        var D = B.extend({
+
+        },{
+            xclass : 'a-b-d'
+        });
+
+
+        it('only xclass',function(){
+            var a = new A({
+                children : [
+                    {xclass : 'a-b-d'}
+                ]            
+            });
+            a.render();
+            var children = a.get('children');
+            expect(children[0] instanceof D).toBe(true);
+        });
+
+        it('only prefixXClass',function(){
+            var a = new A({
+                children : [
+                    {}
+                ]            
+            });
+            a.render();
+            var children = a.get('children');
+            expect(children[0] instanceof B).toBe(true);
+        });
+
+        it('prefixXClass + xtype',function(){
+            var a = new A({
+                children : [
+                    {xtype : 'c'}
+                ]            
+            });
+            a.render();
+            var children = a.get('children');
+            expect(children[0] instanceof C).toBe(true);
+        });
+
+        it('xclass and prefixXClass + xtype',function(){
+            var a = new A({
+                children : [
+                    {xtype : 'c',xclass : 'a-b-d'}
+                ]            
+            });
+            a.render();
+            var children = a.get('children');
+            expect(children[0] instanceof D).toBe(true);
+        });
+    });
+
 });


### PR DESCRIPTION
1. 添加了 xtype 的支持：

this.xclass =  this.xlcass || defaultChildCfg.prefixXClass + this.xtype

例如： 
var A = Component.Controller.extend({

```
    },{
        ATTRS : {
            defaultChildCfg : {
                value : {
                    prefixXClass : 'a-b'
                }
            }
        }
    },{
        xclass : 'a'
    });

    var B = Component.Controller.extend({},{
        xclass : 'a-b'
    });

    var C = B.extend({

    },{
        xclass : 'a-b-c'
    });
```

new A({
   children : [
      {} // xclass = 'a-b'
  ]
}).render();

new A({
   children : [
      {xtype : 'c'} // xclass = 'a-b-c'
  ]
}).render();
