### PR TITLE
fix issue #485

### DIFF
--- a/src/seed/src/loader/configs.js
+++ b/src/seed/src/loader/configs.js
@@ -71,7 +71,13 @@
         if (modules) {
             S.each(modules, function (modCfg, modName) {
                 Utils.createModuleInfo(self, modName, modCfg);
-                S.mix(Env.mods[modName], modCfg);
+                var modObj = Env.mods[modName];
+
+                if(modObj && modObj.requires){
+                    delete modCfg.requires;
+                }
+
+                S.mix(modObj, modCfg);
             });
         }
     };


### PR DESCRIPTION
在config时，如果模块已经存在requires信息了，则忽略config中的信息。不影响add时对requires的更改
