### PR TITLE
fixed container is Array & container[0] is hidden Ele

### DIFF
--- a/src/datalazyload/src/datalazyload.js
+++ b/src/datalazyload/src/datalazyload.js
@@ -350,21 +350,28 @@ KISSY.add('datalazyload', function (S, DOM, Event, Base, undefined) {
             var self = this,
                 containerRegion,
                 container = self.get('container'),
-                windowRegion;
-            // container is display none
-            if (self._containerIsNotDocument && !container.offsetWidth) {
-                return;
+                windowRegion,
+                userConfig = self.userConfig,
+                containers = [container];
+            // 兼容 1.2 传入数组
+            if (S.isArray(userConfig.container)) {
+                containers = userConfig.container;
             }
-            windowRegion = self['_getBoundingRect']();
-            // 兼容，不检测 container
-            if (!self._backCompact && self._containerIsNotDocument) {
-                containerRegion = self['_getBoundingRect'](self.get('container'));
-            }
-            self['_loadImgs'](windowRegion, containerRegion);
-            self['_loadTextAreas'](windowRegion, containerRegion);
-            self['_fireCallbacks'](windowRegion, containerRegion);
+            S.each(containers,function(container){
+                // container is display none
+                if (self._containerIsNotDocument && !container.offsetWidth) {
+                    return;
+                }
+                windowRegion = self['_getBoundingRect']();
+                // 兼容，不检测 container
+                if (!self._backCompact && self._containerIsNotDocument) {
+                    containerRegion = self['_getBoundingRect'](self.get('container'));
+                }
+                self['_loadImgs'](windowRegion, containerRegion);
+                self['_loadTextAreas'](windowRegion, containerRegion);
+                self['_fireCallbacks'](windowRegion, containerRegion);
+            });
         },
-
         /**
          * lazyload images
          * @private


### PR DESCRIPTION
bug场景如：http://jsfiddle.net/stu2006/VtFs7/2/
container的setter使用了return DOM.get(x)，导致当container为数组时取第一个元素，

```
    container: {
        setter: function (el) {
            el = el || doc;
            if (S.isWindow(el)) {
                el = el.document;
            } else {
                el = DOM.get(el);
                if (DOM.nodeName(el) == 'body') {
                    el = el.ownerDocument;
                }
            }
            return el;
        },
```

container[0]是offsetWidth==0状态时，原container所有节点都被中止检测，导致lazyload失败

```
        if (self._containerIsNotDocument && !container.offsetWidth) {
            return;
        }
```

解决办法有多种，按_filterItems中兼容1.2的处理办法感觉是最简单的，所以在_loadItems中也使用了这种方式处理，1.3.0 、1.3.2中测试通过

```
        S.each(containers,function(container){
            // container is display none
            if (self._containerIsNotDocument && !container.offsetWidth) {
                return;
            }
            windowRegion = self['_getBoundingRect']();
            // 兼容，不检测 container
            if (!self._backCompact && self._containerIsNotDocument) {
                containerRegion = self['_getBoundingRect'](self.get('container'));
            }
            self['_loadImgs'](windowRegion, containerRegion);
            self['_loadTextAreas'](windowRegion, containerRegion);
            self['_fireCallbacks'](windowRegion, containerRegion);
        });
```
