### PR TITLE
修正默认时间戳

### DIFF
--- a/src/seed/src/loader/init.js
+++ b/src/seed/src/loader/init.js
@@ -125,7 +125,8 @@
             // 2k(2048) url length
             comboMaxUrlLength: 2000,
             // file limit number for a single combo url
-            comboMaxFileNum: 40
+            comboMaxFileNum: 40,
+            tag:TIMESTAMP
         }, getBaseInfo()));
     }
 })(KISSY);


### PR DESCRIPTION
1.4.x默认时间戳丢了 兼容覆盖式发布时模块缓存更新
