### PR TITLE
修复tree组件从已有html生成时点击展开/收起按钮不生效的bug。 fixes #687

### DIFF
--- a/src/component/control/src/control.js
+++ b/src/component/control/src/control.js
@@ -583,7 +583,9 @@ var Control = module.exports = Base.extend({
         $: function (selector) {
             return this.$el.all(selector);
         },
-
+        $one: function (selector) {
+            return this.$el.one(selector);
+        },
         fillChildrenElsBySelectors: function (childrenElSelectors) {
             var self = this,
                 el = self.$el,
@@ -595,7 +597,7 @@ var Control = module.exports = Base.extend({
                 selector = childrenElSelectors[childName];
                 var node = selector.call(self, el);
                 if (typeof node === 'string') {
-                    node = self.$(node);
+                    node = self.$one(node);
                 }
                 self.setInternal(childName, node);
             }


### PR DESCRIPTION
此前通过fillChildrenElsBySelectors获取的子节点有多个，而实际上应该获取的是符合selector的第一个子元素，导致出错。如下有bug的demo，树结构的“收藏夹”点击展开/收起按钮不生效。
[tree demo with bug](http://jsfiddle.net/benfchen/wxuhxj58/)
