### PR TITLE
kissy1.3.x 编辑器 selectionFix里浏览器嗅探改为特性嗅探。 未构建

### DIFF
--- a/src/editor/src/editor/core/selectionFix.js
+++ b/src/editor/src/editor/core/selectionFix.js
@@ -458,7 +458,7 @@ KISSY.add("editor/core/selectionFix", function (S, Editor) {
         init: function (editor) {
             editor.docReady(function () {
                 // S.log("editor docReady for fix selection");
-                if (UA.ie) {
+                if (document.selection) {
                     fixCursorForIE(editor);
                     fixSelectionForIEWhenDocReady(editor);
                 } else {


### PR DESCRIPTION
 http://g.tbcdn.cn/kissy/k/1.3.2/editor.js?t=20131125184002.js
![image1](https://cloud.githubusercontent.com/assets/2062355/4914407/f265f6f4-64c1-11e4-9b1c-1e6347fb526e.png)

上图UA.ie应该是要修改为https://github.com/kissyteam/editor/blob/master/lib/editor/selection-fix.js现在新版editor的 
![image2](https://cloud.githubusercontent.com/assets/2062355/4914410/024e624a-64c2-11e4-8a83-7a9e80e96d78.png)

现在的线上问题就是: IE11已经支持了W3C的dom range，结果走了老IE的处理方式，导致IE11用户出问题了 

虽然是老版本了不过现在线上很多在用 
